### PR TITLE
Rework optimization tooling

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -2,19 +2,19 @@ const optimize = require('./optimize');
 const generatePathFile = require('./path-data');
 
 module.exports = function () {
-  return optimize(['*.svg'], './')
-    .then(function (result) {
-      return optimize(['icons/*.svg'], 'icons/', true);
+  return optimize('*.svg')
+    .then(function () {
+      return optimize('icons/*.svg', true);
     })
-    .catch(error => {
+    .catch(function (error) {
       console.error('🚨  Error while optimizing icons');
       throw error;
     })
-    .then(function (result) {
+    .then(function () {
       console.log('✨  icons optimized successfully');
       return generatePathFile();
     })
-    .catch(error => {
+    .catch(function (error) {
       console.error('🚨  Error while generating icons.json');
       throw error;
     })

--- a/bin/build.js
+++ b/bin/build.js
@@ -3,22 +3,20 @@ const generatePathFile = require('./path-data');
 
 module.exports = function () {
   return optimize('*.svg')
-    .then(function () {
-      return optimize('icons/*.svg', true);
-    })
-    .catch(function (error) {
+    .then(() => optimize('icons/*.svg', true))
+    .catch((error) => {
       console.error('🚨  Error while optimizing icons');
       throw error;
     })
-    .then(function () {
+    .then(() => {
       console.log('✨ icons optimized successfully');
       return generatePathFile();
     })
-    .catch(function (error) {
+    .catch((error) => {
       console.error('🚨  Error while generating icons.json');
       throw error;
     })
-    .then(function (files) {
+    .then((files) => {
       console.log('✨ path file generated at ./docs/icons.json');
       return files;
     });

--- a/bin/build.js
+++ b/bin/build.js
@@ -11,7 +11,7 @@ module.exports = function () {
       throw error;
     })
     .then(function () {
-      console.log('✨  icons optimized successfully');
+      console.log('✨ icons optimized successfully');
       return generatePathFile();
     })
     .catch(function (error) {
@@ -19,7 +19,7 @@ module.exports = function () {
       throw error;
     })
     .then(function (files) {
-      console.log('✨  path file generated at ./docs/icons.json');
+      console.log('✨ path file generated at ./docs/icons.json');
       return files;
     });
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 const build = require('./build');
-
-console.log('🗜  optimizing icons...')
-
 build(true)
   .then(() => process.exit(0))
   .catch(() => process.exit(1));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const build = require('./build');
+console.log('🗜  optimizing icons... \n');
 build(true)
   .then(() => process.exit(0))
   .catch(() => process.exit(1));

--- a/bin/optimize.js
+++ b/bin/optimize.js
@@ -40,7 +40,7 @@ function optimizeIcons (filePaths, svgo, bar) {
         return svgo.optimize(svg, { path: filePath });
       })
       .then(function (result) {
-        num++
+        num++;
         bar.update(num);
         return fs.writeFile(filePath, result.data, 'utf-8');
       });

--- a/bin/optimize.js
+++ b/bin/optimize.js
@@ -1,5 +1,9 @@
-const imagemin = require('imagemin');
-const imageminSvgo = require('imagemin-svgo');
+const fs = require('fs-extra');
+const glob = require('glob-promise');
+const path = require('path');
+const SVGO = require('svgo');
+const progress = require('cli-progress');
+
 let options = {
   plugins: [
     {cleanupIDs: {remove: false}},
@@ -9,6 +13,7 @@ let options = {
     {removeHiddenElems: true},
     {removeEmptyText: true},
     {convertShapeToPath: true},
+    {convertPathData: { noSpaceAfterFlags: false }},
     {removeEmptyAttrs: true},
     {removeEmptyContainers: true},
     {mergePaths: true},
@@ -21,16 +26,48 @@ let options = {
 };
 
 /**
+ * Reads an icon file off disk and optimizes it, saving to same location
+ * @param {array}              filePaths  array of relative file paths
+ * @param {SVGO}               svgo       SVGO instance with correct options
+ * @param {SingleBar}          bar        progress bar instance
+ * @return {promise}
+ */
+function optimizeIcons (filePaths, svgo, bar) {
+  var num = 0;
+  return Promise.all(filePaths.map(function (filePath) {
+    return fs.readFile(filePath, 'utf-8')
+      .then(function (svg) {
+        return svgo.optimize(svg, { path: filePath });
+      })
+      .then(function (result) {
+        num++
+        bar.update(num);
+        return fs.writeFile(filePath, result.data, 'utf-8');
+      });
+  }));
+}
+
+/**
  * Optimize a set of icons
- * @param {array}    files       Array of glob patters
- * @param {string}   output      Relative file path to desired output location
+ * @param {string}   files       Glob pattern for icons source
  * @param {boolean}  removeIds   Remove id attributes from output
  * @return {promise}             Formatted object with all icon metadata
  */
-module.exports = function (files, output, removeIds) {
+module.exports = function (files, removeIds) {
   if (!files) {
     return Promise.resolve(true);
   }
   options.plugins[0] = {cleanupIDs: {remove: removeIds}};
-  return imagemin(files, output, { use: [imageminSvgo(options)] });
+  svgo = new SVGO(options);
+  return glob(files).then(function(iconPaths) {
+    const bar = new progress.SingleBar({
+      format: "  \x1b[32m {bar} {percentage}% | {value}/{total} \x1b[0m"
+    }, progress.Presets.shades_classic);
+    bar.start(iconPaths.length, 0);
+    return optimizeIcons(iconPaths, svgo, bar)
+      .then(function () {
+        bar.stop();
+        console.log("");
+      })
+  });
 }

--- a/bin/optimize.js
+++ b/bin/optimize.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra');
 const glob = require('glob-promise');
-const path = require('path');
 const SVGO = require('svgo');
 const progress = require('cli-progress');
 
@@ -27,22 +26,20 @@ let options = {
 
 /**
  * Reads an icon file off disk and optimizes it, saving to same location
- * @param {array}              filePaths  array of relative file paths
+ * @param {string[]}           filePaths  array of relative file paths
  * @param {SVGO}               svgo       SVGO instance with correct options
  * @param {SingleBar}          bar        progress bar instance
- * @return {promise}
+ * @return {Promise}
  */
 function optimizeIcons (filePaths, svgo, bar) {
   var num = 0;
-  return Promise.all(filePaths.map(function (filePath) {
-    return fs.readFile(filePath, 'utf-8')
-      .then(function (svg) {
-        return svgo.optimize(svg, { path: filePath });
-      })
-      .then(function (result) {
+  return Promise.all(filePaths.map((path) => {
+    return fs.readFile(path, 'utf-8')
+      .then((svg) => svgo.optimize(svg, { path }))
+      .then((result) => {
         num++;
         bar.update(num);
-        return fs.writeFile(filePath, result.data, 'utf-8');
+        return fs.writeFile(path, result.data, 'utf-8');
       });
   }));
 }
@@ -50,24 +47,22 @@ function optimizeIcons (filePaths, svgo, bar) {
 /**
  * Optimize a set of icons
  * @param {string}   files       Glob pattern for icons source
- * @param {boolean}  removeIds   Remove id attributes from output
- * @return {promise}             Formatted object with all icon metadata
+ * @param {boolean}  remove      Remove id attributes from output
+ * @return {Promise}             Formatted object with all icon metadata
  */
-module.exports = function (files, removeIds) {
+module.exports = function (files, remove) {
   if (!files) {
     return Promise.resolve(true);
   }
-  options.plugins[0] = {cleanupIDs: {remove: removeIds}};
+  options.plugins[0] = {cleanupIDs: { remove }};
   svgo = new SVGO(options);
-  return glob(files).then(function(iconPaths) {
-    const bar = new progress.SingleBar({
-      format: "  \x1b[32m {bar} {percentage}% | {value}/{total} \x1b[0m"
-    }, progress.Presets.shades_classic);
+  return glob(files).then((iconPaths) => {
+    const format = "  \x1b[32m {bar} {percentage}% | {value}/{total} \x1b[0m";
+    const bar = new progress.SingleBar({ format }, progress.Presets.shades_classic);
     bar.start(iconPaths.length, 0);
-    return optimizeIcons(iconPaths, svgo, bar)
-      .then(function () {
-        bar.stop();
-        console.log("");
-      })
+    return optimizeIcons(iconPaths, svgo, bar).then(() => {
+      bar.stop();
+      console.log("");
+    });
   });
 }

--- a/bin/server.js
+++ b/bin/server.js
@@ -10,7 +10,7 @@ const options = {
   ignoreInitial: true
 };
 
-console.log('🗜  optimizing icons...')
+console.log('🗜  optimizing icons... \n')
 
 build()
   .then(() => {
@@ -25,8 +25,8 @@ build()
 
     function onChange (event, file) {
       if (event === 'add') {
-        console.log('🗜  new icon detected, optimizing...');
-        optimize(file, 'icons/', true).then(() => {});
+        console.log('🗜  new icon detected, optimizing... \n');
+        optimize(file, true).then(() => {});
       } else {
         update();
       }

--- a/bin/server.js
+++ b/bin/server.js
@@ -4,7 +4,6 @@ const pathData = require('./path-data');
 const optimize = require('./optimize');
 const debounce = require('debounce');
 const bs = require('browser-sync').create();
-const fs = require('fs');
 const options = {
   awaitWriteFinish: true,
   ignoreInitial: true
@@ -34,7 +33,7 @@ build()
 
     const update = debounce(function () {
       pathData()
-        .then(files => {
+        .then(() => {
           console.log('✨  path file updated');
           bs.reload();
         });

--- a/bin/server.js
+++ b/bin/server.js
@@ -25,8 +25,8 @@ build()
 
     function onChange (event, file) {
       if (event === 'add') {
-        console.log('🗜  new icon detected, optimizing...')
-        optimize([file], 'icons/', true).then(() => {});
+        console.log('🗜  new icon detected, optimizing...');
+        optimize(file, 'icons/', true).then(() => {});
       } else {
         update();
       }

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
   "devDependencies": {
     "browser-sync": "^2.24.7",
     "camelcase": "^5.3.1",
+    "cli-progress": "^3.1.0",
     "debounce": "^1.2.0",
     "fs-extra": "^7.0.0",
     "glob-promise": "^3.4.0",
-    "imagemin": "^5.3.1",
-    "imagemin-svgo": "^7.0.0",
     "promise": "~8.0.1",
+    "svgo": "^1.3.0",
     "svgson": "^2.1.1",
     "svgstore-cli": "^1.3.1"
   }


### PR DESCRIPTION
As of svgo 1.3.0, svgo removes spaces in arc paths by default. While these svgs still work in the browser, they break in Illustrator, Sketch, and several other design tools. The way that you turn off this behavior is through setting the following additional plugin information:

```
{convertPathData: { noSpaceAfterFlags: false }}
```

However, because we were using imagemin and imagemin-svgo rather than using svgo directly, they were on a version that didn't allow me to pass in these options. To get around that, I've rewritten the `optimize` script to call `svgo` directly via its node API. 

@johnmgriffith @KatelynSeitz  after this is merged I will open a PR with updated paths for the icons. I didn't want to make this PR huge by committing the changes to the icon path data in the same pr as the changes to the optimization script. Once we have the updated path data with the spaces added back in, I think #84 will be resolved.

I also added a progress bar to make it easier to know how long the optimization will take:

![Screen Shot 2019-09-03 at 5 06 09 PM](https://user-images.githubusercontent.com/1031758/64216312-37891a80-ce6d-11e9-994c-d931139344ae.png)


