### PR TITLE
Captures icons previously missed by convert-mobile.js

### DIFF
--- a/bin/convert-mobile.js
+++ b/bin/convert-mobile.js
@@ -5,33 +5,39 @@ const svg2img = require('svg2img');
 const path = require('path');
 const yargs = require('yargs');
 
-const baseIconPath = './icons/';
-var sourceIconSuffix = '-32.svg';
-// default output path, can be overridden
-var outputRoot = path.join(__dirname, 'output')
-// default output size, can be overridden
-var outputSize = 24;
+const options = yargs
+  .usage('Usage: -n <name of icon, omit if doing bulk>, \n-s <output size, defaults to 24>, \n-o <output path (defaults to ./output)>, \n-p <target platform (e.g. ios) \n-i <16, 24, 32, omit for 16>')
+  .option('n', { alias: 'name', describe: 'name of icon, without -32.svg; omit to convert all icons', type: 'string', demandOption: false })
+  .option('o', { alias: 'outputDir', describe: 'output path, relative to this script', type: 'string', demandOption: false })
+  .option('p', { alias: 'outputPlatform', describe: 'target platform, valid options are: ios', type: 'string', demandOption: false })
+  .option('i', { alias: 'inSize', describe: 'source svg variant, defaults to 16', type: 'string', demandOption: false })
+  .option('s', { alias: 'outSize', describe: 'size of output image', type: 'string', demandOption: false})
+  .argv;
 
 /**
- * Converts a single svg to png, with given width & height values
- * @param {string} iconName - name of the icon, without size or file extension (e.g. '2d-explore')
+ * Converts a single svg to png, with given width & height values. The function will automatically append '.png'
+ * @param {string} svgFilePath - filepath to icon .svg
  * @param {int} width - width of output file
  * @param {int} height - height of output file
- * @param {string} outputRoot - base directory in which to store output
- * @param {string} outputSuffix - suffix appended to output file (e.g. '.png')
+ * @param {string} outputBasePath - base directory in which to store output
+ * @param {string} outputName - name of output png image, excluding '.png'
+ * @param {string} outputSuffix - suffix appended to output file name (ex, '@2x')
  */
-function convertSingleIconToPng(iconName, width, height, outputRoot, outputSuffix) {
-  // make paths and whatnot
-  const sourceSvgIconPath = path.join(baseIconPath, iconName + sourceIconSuffix);
-  const real_output_path = path.join(outputRoot, iconName + outputSuffix);
-
-  // make sure output path exists
-  if (!fs.existsSync(outputRoot)) {
-    fs.mkdirSync(outputRoot, { recursive: true });
+function convertSingleIconToPng(svgFilePath, width, height, outputBasePath, outputName, outputSuffix=null) {
+  // make sure output base path exists
+  if (!fs.existsSync(outputBasePath)) {
+    fs.mkdirSync(outputBasePath, {
+      recursive: true
+    });
   }
-
+  // concatenate real output path
+  let real_output_path = path.join(outputBasePath, outputName);
+  if (outputSuffix) {
+    real_output_path += outputSuffix
+  }
+  real_output_path += '.png'
   // convert and save the image
-  svg2img(sourceSvgIconPath, { 'width': width, 'height': height }, function (error, buffer) {
+  svg2img(svgFilePath, { 'width': width, 'height': height }, function (error, buffer) {
     if (error){
       console.log(error);
       process.exit(1);
@@ -42,118 +48,171 @@ function convertSingleIconToPng(iconName, width, height, outputRoot, outputSuffi
 
 /**
  * Creates an ImageSet (including Contents.json file) for an icon
- * @param {string} iconName - name of the icon without size or extension (e.g. '2d-explore')
- * @param {int} baseSize - base (smallest) size of the icon at @1x
- * @param {string} outputRoot - base directory in which to store the imageset folder
+ * @param {string} svgFilePath - filepath to icon .svg
+ * @param {int} width - width of output file @1x
+ * @param {int} height - height of output file @1x
+ * @param {string} outputBasePath - base directory in which to store output
+ * @param {string} outputName - name of output png image, excluding '.png'
  */
-function convertIconToXcodeImageSet(iconName, baseSize, outputRoot) {
-  const new_output_root = path.join(outputRoot, iconName + '.imageset');
+function convertIconToXcodeImageSet(svgFilePath, width, height, outputBasePath, outputName) {
+  const outputImagesetPath = path.join(outputBasePath, outputName + '.imageset');
 
   // Create images at 3 sizes
-  convertSingleIconToPng(iconName, baseSize, baseSize, new_output_root, '@1x.png');
-  convertSingleIconToPng(iconName, baseSize * 2, baseSize * 2, new_output_root, '@2x.png');
-  convertSingleIconToPng(iconName, baseSize * 3, baseSize * 3, new_output_root, '@3x.png');
+  convertSingleIconToPng(svgFilePath, width, height, outputImagesetPath, outputName, '@1x');
+  convertSingleIconToPng(svgFilePath, width * 2, height * 2, outputImagesetPath, outputName, '@2x');
+  convertSingleIconToPng(svgFilePath, width * 3, height * 3, outputImagesetPath, outputName, '@3x');
 
   // read template
-  const template_path = path.join(__dirname, 'templates', 'imageset.json');
-
-  fs.readFile(template_path, 'utf8', function (error, buffer) {
-    if (error){
+  const imagesetTemplatePath = path.join(__dirname, 'templates', 'imageset.json');
+  // create Contents.json for asset catalog asset
+  fs.readFile(imagesetTemplatePath, 'utf8', function (error, buffer) {
+    if (error) {
       console.log(error);
       process.exit(1);
     }
-    const new_output_string = buffer.replace(/\$\{NAME\}/g, iconName);
-    const contents_output_path = path.join(new_output_root, 'Contents.json');
-    fs.writeFile(contents_output_path, new_output_string, function (error) { });
+    const contentsJsonBuffer = buffer.replace(/\$\{NAME\}/g, outputName);
+    const contentsJsonOutputPath = path.join(outputImagesetPath, 'Contents.json');
+    fs.writeFileSync(contentsJsonOutputPath, contentsJsonBuffer)
   });
 }
 
-const options = yargs
-  .usage('Usage: -n <name of icon, omit if doing bulk>, \n-s <output size, defaults to 24>, \n-o <output path (defaults to ./output)>, \n-p <target platform (e.g. ios) \n-i <16, 24, 32, omit for 16>')
-  .option('n', { alias: 'name', describe: 'name of icon, without -32.svg; omit to convert all icons', type: 'string', demandOption: false })
-  .option('o', { alias: 'outputDir', describe: 'output path, relative to this script', type: 'string', demandOption: false })
-  .option('p', { alias: 'outputPlatform', describe: 'target platform, valid options are: ios', type: 'string', demandOption: false })
-  .option('i', { alias: 'inSize', describe: 'source svg variant, defaults to 16', type: 'string', demandOption: false })
-  .option('s', {alias: 'outSize', describe: 'size of output image', type: 'string', demandOption: false})
-  .argv;
-
-if (options.outputDir) {
-  outputRoot = path.join(__dirname, options.outputDir);
-}
-
-// update output size if set
-if (options.outSize){
-  outputSize = parseInt(options.outSize);
-}
-
-// update source icon size based on output size if source not explicitly set
-if (!options.inSize && options.outSize){
-  if (options.outSize < 24){
-    sourceIconSuffix = '-16.svg';
-  } else if (options.outSize < 32){
-    sourceIconSuffix = '-24.svg';
-  } else {
-    sourceIconSuffix = '-32.svg';
-  }
-}
-
-// set insize if explicitly set
-if (options.inSize === '16'){
-  sourceIconSuffix = '-16.svg';
-} else if (options.inSize === '24'){
-  sourceIconSuffix = '-24.svg';
-} else if (options.inSize === '32'){
-  sourceIconSuffix = '-32.svg';
-}
-
-if (options.outputPlatform === 'ios'){
-  // Put in .xcassets folder
-  outputRoot = path.join(outputRoot, 'calcite.xcassets');
-  
-  // Make sure dir exists
-  if (!fs.existsSync(outputRoot)) {
-    fs.mkdirSync(outputRoot, { recursive: true });
-  }
-
-  // read contents.json template
-  const template_path = path.join(__dirname, 'templates', 'xcassets.json');
-
-  // write out file
-  fs.readFile(template_path, 'utf8', function (error, buffer) {
-    if (error){
-      console.log(error);
-      process.exit(1);
-    }
-    const contents_output_path = path.join(outputRoot, 'Contents.json');
-    fs.writeFile(contents_output_path, buffer, function (error) { });
-  });
-}
-
-if (options.name) {
-  if (options.outputPlatform === 'ios') {
-    convertIconToXcodeImageSet(options.name, outputSize, outputRoot);
-  } else {
-    convertSingleIconToPng(options.name, outputSize, outputSize, outputRoot, `-${outputSize}.png`);
-  }
-} else {
-  fs.readdir(baseIconPath, function (err, files) {
-    //handling error
-    if (err) {
-      console.log(err);
-      process.exit(1);
-    }
-    //listing all files using forEach
-    files.forEach(function (file) {
-      const base_name = path.basename(file);
-      if (base_name.endsWith('-16.svg')) {
-        const iconName = base_name.substring(0, base_name.length - 7);
-
-        if (options.outputPlatform === 'ios') {
-          convertIconToXcodeImageSet(iconName, outputSize, outputRoot);
-        } else {
-          convertSingleIconToPng(iconName, outputSize, outputSize, outputRoot, `-${outputSize}.png`);
-        }
+/**
+ * Indexes all calcite icons contained in directory at path
+ * @param {string} baseIconPath - path to calcite .svg icons directory
+ */
+async function indexCalciteIcons(baseIconPath) {
+  return new Promise(resolve => {
+    var iconIndex = {};
+    fs.readdir(baseIconPath, function (error, files) {
+      if (error) {
+        console.log(error);
+        process.exit(1);
       }
+      files.forEach(function (file) {
+        // strip all files of file size information, catalog in an index
+        var base_name = path.basename(file);
+        base_name = base_name.replace('.svg', '');
+        var size = undefined;
+        if (base_name.includes('-16')) {
+          base_name = base_name.replace('-16', '');
+          size = 16;
+        }
+        else if (base_name.includes('-24')) {
+          base_name = base_name.replace('-24', '');
+          size = 24;
+        }
+        else if (base_name.includes('-32')) {
+          base_name = base_name.replace('-32', '');
+          size = 32;
+        }
+        if (!iconIndex[base_name]) {
+          iconIndex[base_name] = {}
+        }
+        iconIndex[base_name][size] = path.join(baseIconPath, file);
+      });
+      resolve(iconIndex);
     });
   });
 }
+
+/**
+ * Indexes all calcite icons contained in directory at path
+ * @param {string} xcAssetsBaseDirectory - path where to derive calcite.xcassets
+ */
+async function createCalciteXCAssets(xcAssetsBaseDirectory) {
+  return new Promise(resolve => {
+    // Put in .xcassets folder
+    var directory = path.join(xcAssetsBaseDirectory, 'calcite.xcassets');
+    // Make sure dir exists
+    if (!fs.existsSync(directory)) {
+      fs.mkdirSync(directory, {
+        recursive: true
+      });
+    }
+    // read contents.json template
+    let template_path = path.join(__dirname, 'templates', 'xcassets.json');
+    // write out file
+    fs.readFile(template_path, 'utf8', function (error, buffer) {
+      if (error) {
+        console.log(error);
+        process.exit(1);
+      }
+      const contents_output_path = path.join(directory, 'Contents.json');
+      fs.writeFile(contents_output_path, buffer, function (error) {
+        resolve(directory);
+      });
+    });
+  });
+}
+
+async function main() {
+  // index all calcite icons
+  let iconIndex = await indexCalciteIcons('./icons/');
+  // establish output root path
+  var outputRoot = path.join(__dirname, 'output')
+  if (options.outputDir) {
+    outputRoot = path.join(__dirname, options.outputDir);
+  }
+  // establish input size
+  var inputSize = 24;
+  if (options.inSize === '16'){
+    inputSize = 16;
+  } else if (options.inSize === '24'){
+    inputSize = 24;
+  } else if (options.inSize === '32'){
+    inputSize = 32;
+  } else if (options.outSize) {
+    let size = parseInt(options.outSize);
+    if (size < 24) {
+      inputSize = 16;
+    } else if (size < 32) {
+      inputSize = 24;
+    } else if (size >= 32) {
+      inputSize = 32;
+    }
+  }
+  // establish output size (in pixels)
+  var outputSize = 24;
+  if (options.outSize) {
+    let size = parseInt(options.outSize);
+    if (size) {
+      outputSize = size;
+    }
+  }
+  // ensure icon name is valid, checking index
+  if (options.name) {
+    if (!(options.name in iconIndex)) {
+      console.log("Invalid icon name " + options.name);
+      process.exit(1);
+    }
+  }
+  // build xcassets if output for iOS
+  if (options.outputPlatform === 'ios') {
+    let xcAssetsDirectory = await createCalciteXCAssets(outputRoot);
+    if (options.name) {
+      let name = options.name;
+      let file = iconIndex[name][inputSize];
+      convertIconToXcodeImageSet(file, outputSize, outputSize, xcAssetsDirectory, name);
+    }
+    else {
+      for (let key in iconIndex) {
+        let file = iconIndex[key][inputSize];
+        convertIconToXcodeImageSet(file, outputSize, outputSize, xcAssetsDirectory, key)
+      }
+    }
+  } else { // platform is not ios, render plain png
+    if (options.name) {
+      let name = options.name;
+      let file = iconIndex[name][inputSize];
+      convertSingleIconToPng(file, outputSize, outputSize, outputRoot, name, undefined);
+    }
+    else {
+      for (let key in iconIndex) {
+        let file = iconIndex[key][inputSize];
+        convertSingleIconToPng(file, outputSize, outputSize, outputRoot, key, undefined);
+      }
+    }
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "optimize": "node bin/cli.js",
     "start": "npm run buildsprite-16 && npm run buildsprite-24 && npm run buildsprite-32 && npm run optimize",
     "server": "node bin/server.js",
-    "convert-all-ios": "node bin/convert-mobile.js -o \"../mobile-output\" -p \"ios\" -i \"16\"",
-    "convert-all-ios:size": "node bin/convert-mobile.js -o \"../mobile-output\" -i \"16\" -p \"ios\" -s",
+    "convert-all-ios": "node bin/convert-mobile.js -o \"../mobile-output\" -p \"ios\" -i \"24\"",
+    "convert-all-ios:size": "node bin/convert-mobile.js -o \"../mobile-output\" -p \"ios\" -s",
     "convert-all-desktop:size": "node bin/convert-mobile.js -o \"../desktop-output\" -i \"16\" -s",
     "convert-all-desktop-multi": "node bin/convert-mobile.js -o \"../desktop-output\" -i \"16\" -s 16 && node bin/convert-mobile.js -o \"../desktop-output\" -s 24 && node bin/convert-mobile.js -o \"../desktop-output\" -s 32 && node bin/convert-mobile.js -o \"../desktop-output\" -s 64"
   },


### PR DESCRIPTION
Currently, `convert-mobile.js` misses "focused" icons. Focused icons are icons that qualify the .svg icon with an additional `-f` after the size (ex, `-16`) and before the suffix (`.png`). Some examples of focused icons include:

- `beginning-16-f.png`
- `check-circle-16-f.png`
- `gps-on-16-f.png`

etc...

This PR introduces support for capturing these icons as well. Additionally, this PR tries to clean up the script a bit by introducing an icon index, augmenting the design to more of a functional programming implementation and variable scoping. Lastly, this PR modifies some default iOS parameters supplied by `npm` scripts.

The result of this change is an identical API to what exists now with the added benefit that now focused icons are captured as well.