### PR TITLE
docs(open-book): uppercase category value

### DIFF
--- a/docs/keywords.json
+++ b/docs/keywords.json
@@ -7664,7 +7664,7 @@
             "literature",
             "objects"
         ],
-        "category": "objects",
+        "category": "Objects",
         "release": "3.16.4"
     }, 
     "bring-forward":{


### PR DESCRIPTION
The category value for the `open-book` icon was lowercase, it should be upper case like the rest of the `Object` category values. The doc shows both the uppercase and lowercase object categories: https://developers.arcgis.com/calcite-design-system/icons/