### PR TITLE
ci: add npm registry url to release action

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release to NPM


### PR DESCRIPTION
The [npm release CI is having auth issues](https://github.com/Esri/calcite-ui-icons/actions/runs/4513599733/jobs/7948644270#step:4:11050) and this is the only difference between the [deploy action I set up in CC](https://github.com/Esri/calcite-components/blob/master/.github/workflows/deploy-next.yml). I assumed this was the default value, but adding it just to be sure.