### PR TITLE
ci(release): move token to publish step

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -13,10 +13,8 @@ jobs:
         with:
           node-version: lts/*
           registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm start
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Release to NPM
-        run: |
-          npm i
-          npm start
-          npm publish


### PR DESCRIPTION
Adds the `NPM_TOKEN` to the publish step, which is how it's [shown in the setup-node doc](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm).

Adding the token to the setup-node step works correctly in CC, but I'm not sure what else could be causing problems. Unless I don't have publish permissions for this package.

merging, cc @paulcpederson 