### PR TITLE
ci: use npm install to prevent no package-lock.json errors

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: lts/*
           registry-url: "https://registry.npmjs.org"
-      - run: npm ci
+      - run: npm i
       - run: npm start
       - run: npm publish
         env:


### PR DESCRIPTION
It looks like this repo doesn't commit `package-lock.json` so the NPM release action was [throwing an error](https://github.com/Esri/calcite-ui-icons/actions/runs/5672143681/job/15370758237) when trying to `npm ci`. I recommend committing `package-lock.json` if there isn't a reason it's ignored, but I switched to `npm i` for now.