### PR TITLE
add missing glob package

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cli-progress": "^3.1.0",
     "debounce": "^1.2.0",
     "fs-extra": "^7.0.0",
+    "glob": "^7.1.4",
     "glob-promise": "^3.4.0",
     "promise": "~8.0.1",
     "svgo": "^1.3.0",


### PR DESCRIPTION
glob promise changed their library to use glob as a peer dependency, meaning we now need to install it ourselves. 